### PR TITLE
Fixed an exception for persons with no username

### DIFF
--- a/src/Gerrie/Gerrie.php
+++ b/src/Gerrie/Gerrie.php
@@ -1490,6 +1490,10 @@ class Gerrie
             $person['name'] = 'Unknown (Exporter)';
         }
 
+        if (array_key_exists('username', $person) === false) {
+            $person['username'] = 'Unknown_export_username';
+        }
+
         // Sometimes you got an action by "Gerrit Code Review".
         // This "system user" does not have a username. Sad, isn`t ?
         // We got a present for him / her. A default username :)


### PR DESCRIPTION
I got an exception while crawling CyanogenMod gerrit. This fixed it and it's working like a charm now.